### PR TITLE
Pin uv version in docker file and change uv install dir to .local

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 FROM python:3.11-slim-bookworm
 
+ARG UV_VERSION=0.5.0
+
 RUN apt-get -y update; apt-get -y install curl git
 
-ADD --chmod=755 https://astral.sh/uv/install.sh /install.sh
+ADD --chmod=755 https://astral.sh/uv/${UV_VERSION}/install.sh /install.sh
 RUN /install.sh && rm /install.sh
 
 COPY requirements.txt /requirements.txt
 
-RUN /root/.cargo/bin/uv pip install --system --no-cache -r requirements.txt
+RUN /root/.local/bin/uv pip install --system --no-cache -r requirements.txt
 
 COPY main.py /main.py
 


### PR DESCRIPTION
# Context
All the context and investigation here: https://github.com/Titan-Systems/titan-core-action/issues/10

# Changes
- Pinned uv version in the Dockerfile
- For uv==0.5.0, use `.local` instead of `.cargo` as uv installation directory